### PR TITLE
Update README.md

### DIFF
--- a/platforms/android/README.md
+++ b/platforms/android/README.md
@@ -20,7 +20,7 @@ Then add tangram-es in the 'dependencies' section of your module's 'build.gradle
 
 ```
 dependencies {
-  compile 'com.mapzen.tangram:tangram:$latest_version'
+  implementation 'com.mapzen.tangram:tangram:$latest_version'
 }
 ```
 


### PR DESCRIPTION
compile is already deprecated after Gradle 3.4,
use implementation instead